### PR TITLE
refactor(api): rename 'CommandArgsOverrides' to 'CliOverrides'

### DIFF
--- a/api/v1alpha1/kafkacluster_types.go
+++ b/api/v1alpha1/kafkacluster_types.go
@@ -157,7 +157,7 @@ type BrokersSpec struct {
 	PodDisruptionBudget *PodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	CommandArgsOverrides []string `json:"commandArgsOverrides,omitempty"`
+	CliOverrides []string `json:"cliOverrides,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	ConfigOverrides *ConfigOverridesSpec `json:"configOverrides,omitempty"`
@@ -175,7 +175,7 @@ type BrokersRoleGroupSpec struct {
 	Config *BrokersConfigSpec `json:"config,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	CommandArgsOverrides []string `json:"commandArgsOverrides,omitempty"`
+	CliOverrides []string `json:"cliOverrides,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	ConfigOverrides *ConfigOverridesSpec `json:"configOverrides,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -121,8 +121,8 @@ func (in *BrokersRoleGroupSpec) DeepCopyInto(out *BrokersRoleGroupSpec) {
 		*out = new(BrokersConfigSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.CommandArgsOverrides != nil {
-		in, out := &in.CommandArgsOverrides, &out.CommandArgsOverrides
+	if in.CliOverrides != nil {
+		in, out := &in.CliOverrides, &out.CliOverrides
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
@@ -179,8 +179,8 @@ func (in *BrokersSpec) DeepCopyInto(out *BrokersSpec) {
 		*out = new(PodDisruptionBudgetSpec)
 		**out = **in
 	}
-	if in.CommandArgsOverrides != nil {
-		in, out := &in.CommandArgsOverrides, &out.CommandArgsOverrides
+	if in.CliOverrides != nil {
+		in, out := &in.CliOverrides, &out.CliOverrides
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crd/bases/kafka.zncdata.dev_kafkaclusters.yaml
+++ b/config/crd/bases/kafka.zncdata.dev_kafkaclusters.yaml
@@ -41,7 +41,7 @@ spec:
             properties:
               brokers:
                 properties:
-                  commandArgsOverrides:
+                  cliOverrides:
                     items:
                       type: string
                     type: array
@@ -1412,7 +1412,7 @@ spec:
                   roleGroups:
                     additionalProperties:
                       properties:
-                        commandArgsOverrides:
+                        cliOverrides:
                           items:
                             type: string
                           type: array

--- a/internal/controller/statefulset.go
+++ b/internal/controller/statefulset.go
@@ -91,7 +91,7 @@ func (s *StatefulSetReconciler) SetAffinity(resource client.Object) {
 func (s *StatefulSetReconciler) CommandOverride(resource client.Object) {
 	dep := resource.(*appv1.StatefulSet)
 	containers := dep.Spec.Template.Spec.Containers
-	if cmdOverride := s.MergedCfg.CommandArgsOverrides; cmdOverride != nil {
+	if cmdOverride := s.MergedCfg.CliOverrides; cmdOverride != nil {
 		for i := range containers {
 			if containers[i].Name == string(common.Kafka) {
 				containers[i].Command = cmdOverride


### PR DESCRIPTION
References https://github.com/zncdatadev/trino-operator/issues/154
