### PR TITLE
fix(ci): add --config to release chainsaw and rename make target to helm-chart-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,7 +329,7 @@ jobs:
 
           # E2E tests
           make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
 
   release-chart:

--- a/test/e2e/.chainsaw.yaml
+++ b/test/e2e/.chainsaw.yaml
@@ -3,12 +3,14 @@ kind: Configuration
 metadata:
   name: custom-config
 spec:
+  # namespace: chainsaw
   timeouts:
     apply: 120s
-    assert: 120s
-    cleanup: 240s
+    assert: 400s
+    cleanup: 120s
     delete: 240s
-    error: 10s
-    exec: 120s
+    error: 120s
+    exec: 200s
+  # skipDelete: true
   failFast: true
   parallel: 1

--- a/test/e2e/.chainsaw.yaml
+++ b/test/e2e/.chainsaw.yaml
@@ -3,14 +3,12 @@ kind: Configuration
 metadata:
   name: custom-config
 spec:
-  # namespace: chainsaw
   timeouts:
     apply: 120s
-    assert: 400s
-    cleanup: 120s
+    assert: 120s
+    cleanup: 240s
     delete: 240s
-    error: 120s
-    exec: 200s
-  # skipDelete: true
+    error: 10s
+    exec: 120s
   failFast: true
   parallel: 1


### PR DESCRIPTION
## Changes

1. **Add `--config` to release.yml chainsaw test** — Ensures chainsaw uses configured timeouts from `.chainsaw.yaml` instead of default 30s
2. **Rename `make chart-publish` to `make helm-chart-publish`** — Consistent with zookeeper-operator convention
3. **Align `.chainsaw.yaml` timeout values** with project standard (assert: 120s, cleanup: 240s, error: 10s, exec: 120s)