### PR TITLE
build(deps): bump Go to 1.25.8 and update Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/zncdatadev/go-devel:1.25.5-kubedoop0.0.0-dev AS builder
+FROM quay.io/zncdatadev/go-devel:1.25.8-kubedoop0.0.0-dev AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zncdatadev/kafka-operator
 
-go 1.25.3
+go 1.25.8
 
 require (
 	emperror.dev/errors v0.8.1


### PR DESCRIPTION
- go.mod: go 1.25.3 → 1.25.8
- Dockerfile: go-devel base image 1.25.5 → 1.25.8