### PR TITLE
chore: update product-version matrix to include Kafka 4.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           '1.34.3',
           '1.35.0'
         ]
-        product-version: ['3.7.2', '3.8.0', '3.9.0']
+        product-version: ['3.7.2', '3.8.0', '3.9.0', '4.0.0']
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           # '1.34.3',
           '1.35.0'
         ]
-        product-version: ['3.7.2', '3.8.0', '3.9.0']
+        product-version: ['3.7.2', '3.8.0', '3.9.0', '4.0.0']
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/api/v1alpha1/image.go
+++ b/api/v1alpha1/image.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	DefaultRepository     = "quay.io/zncdatadev"
-	DefaultProductVersion = "3.9.0"
+	DefaultProductVersion = "4.0.0"
 	DefaultProductName    = "kafka"
 )
 


### PR DESCRIPTION
## Description

Update product-version matrix to include Kafka 4.0.0 and change DefaultProductVersion to 4.0.0.

## ⚠️ On Hold

This PR is blocked by **#280** — Kafka 4.0.0 has completely removed ZooKeeper mode and requires KRaft mode. The current operator still uses ZooKeeper mode, causing broker startup failure:

```
ConfigException: Missing required configuration "process.roles" which has no default value.
```

CI results: 3.7.2/3.8.0/3.9.0 all pass. Only 4.0.0 fails in the kerberos test due to this KRaft requirement.

This PR will remain on hold until KRaft mode support is implemented.